### PR TITLE
Add prefacer as a contributor's role

### DIFF
--- a/data/imml_kit.rnc
+++ b/data/imml_kit.rnc
@@ -463,7 +463,7 @@ imml.book.assets.mimetype.datatype =
   | "application/epub+zip"
 imml.book.contributor.datatype =
   list {
-    "author" | "translator" | "editor" | "typesetter" | "illustrator"
+    "author" | "translator" | "editor" | "typesetter" | "illustrator" | "prefacer"
   }
 imml.bisac.id.datatype = xsd:token { pattern = "[A-Z]{3}[0-9]{6}" }
 imml.clil.id.datatype = xsd:token { pattern = "[0-9]{4}" }

--- a/data/imml_kit.rng
+++ b/data/imml_kit.rng
@@ -1033,6 +1033,7 @@ See http://www.relaxng.org/compact-tutorial-20030326.html#id2816343</a:documenta
         <value>editor</value>
         <value>typesetter</value>
         <value>illustrator</value>
+        <value>prefacer</value>
       </choice>
     </list>
   </define>


### PR DESCRIPTION
Hello, we use this gem to parse metadata we receive to integrate into our system. It has been working great so far!

But we sometimes receive immateriel metadata where a contributor is a prefacer. That breaks the current version of the gem.

This change adds prefacer as a role.

There might be other constraints about prefacers I am not aware of.